### PR TITLE
Prevent support requests for "revert_on_unclaim"

### DIFF
--- a/src/com/palmergames/bukkit/config/ConfigNodes.java
+++ b/src/com/palmergames/bukkit/config/ConfigNodes.java
@@ -446,6 +446,8 @@ public enum ConfigNodes {
 			"",
 			"",
 			"# This section is applied to new worlds as default settings when new worlds are detected."),
+	        "# You can adjust these settings for existing worlds using /townyworld ?"),
+	
 	NWS_PLOT_MANAGEMENT_REVERT_ENABLE(
 			"new_world_settings.plot_management.revert_on_unclaim.enabled",
 			"true",


### PR DESCRIPTION
#### Description: 
Adds a note reading "You can adjust these settings for existing worlds using /townyworld ?" to the configuration description just above revert_on_unclaim section.

____
#### New Nodes/Commands/ConfigOptions: 
Adjustment to configuration description.


____
#### Relevant Towny Issue ticket:
Not that I am aware of.


____
- [ ] I have tested this pull request for defects on a server. 
-- I have not tested this with a build as I am just updating a description.

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
